### PR TITLE
Vanilla upgrade 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "autoprefixer": "9.5.1",
     "sass-lint": "1.12.1",
-    "vanilla-framework": "1.8.1",
+    "vanilla-framework": "2.0.0-alpha.1",
     "watch-cli": "0.2.3",
     "postcss-cli": "6.1.2",
     "node-sass": "4.11.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "autoprefixer": "9.5.1",
     "sass-lint": "1.12.1",
-    "vanilla-framework": "2.0.0-alpha.1",
+    "vanilla-framework": "2.0.1",
     "watch-cli": "0.2.3",
     "postcss-cli": "6.1.2",
     "node-sass": "4.11.0"

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,66 +1,58 @@
 {% block footer %}
-<footer class="p-footer u-no-margin--top u-clearfix">
-  <div class="row p-footer__container">
-    <p class="u-hide--medium u-hide--large link-to-top"><a href="#"><small>Back to top</small></a></p>
-    <div class="p-footer--secondary">
-      <div class="col-8">
-        <nav>
-          <ul class="p-inline-list">
-            <li class="u-hide--small p-inline-list__item">
-              <a class="p-button--neutral is-compact" href="https://www.ubuntu.com/contact-us"><small>Contact us</small></a>
-            </li>
-            <li class="u-hide--medium is-compact u-hide--large p-inline-list__item">
-              <a class="p-link--soft" href="https://www.ubuntu.com/contact-us"><small>Contact us</small></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--soft" href="https://www.ubuntu.com/about"><small>About us</small></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--soft" href="https://www.ubuntu.com/community"><small>Community</small></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--soft" href="http://www.canonical.com/careers"><small>Careers</small></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--soft" href="https://insights.ubuntu.com/press-centre/"><small>Press centre</small></a>
-            </li>
-          </ul>
-        </nav>
+<div class="p-strip is-shallow">
+  <div class="row">
+    <p class="u-hide--medium u-hide--large link-to-top"><a href="#">Back to top</a></p>
+    <div class="col-8">
+      <ul class="p-inline-list">
+        <li class="u-hide--small p-inline-list__item">
+          <a class="p-button--neutral" href="https://www.ubuntu.com/contact-us">Contact us</a>
+        </li>
+        <li class="u-hide--medium u-hide--large p-inline-list__item">
+          <a class="p-link--soft" href="https://www.ubuntu.com/contact-us">Contact us</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--soft" href="https://www.ubuntu.com/about">About us</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--soft" href="https://www.ubuntu.com/community">Community</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--soft" href="http://www.canonical.com/careers">Careers</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--soft" href="https://insights.ubuntu.com/press-centre/">Press centre</a>
+        </li>
+      </ul>
 
-        <p class="p-footer--secondary__content"><small>&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</small></p>
-        <nav>
-          <ul class="p-inline-list--middot u-no-margin--bottom">
-            <li class="p-inline-list__item">
-              <a class="p-link--soft" accesskey="8" href="https://www.ubuntu.com/legal"><small>Legal information</small></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--soft" accesskey="9" href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"><small>Cookie policy</small></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--soft" href="https://github.com/canonical-websites/docs.ubuntu.com/issues/new" id="report-a-bug"><small>Report a bug on this site</small></a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-      <div class="col-4">
-        <ul class="p-inline-list u-align--center u-no-margin--top">
-          <li class="p-inline-list__item">
-            <a href="https://twitter.com/ubuntu" title="Share on Twitter"><i class="p-icon--twitter"></i></a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://www.facebook.com/ubuntulinux/" title="Share on Facebook"><i class="p-icon--facebook"></i></a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://www.linkedin.com/company-beta/234280/?pathWildcard=234280" title="Share on LinkedIn"><i class="p-icon--linkedin"></i></a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://twitter.com/ubuntu" title="Share on Twitter"><i class="p-icon--google"></i></a>
-          </li>
-        </ul>
-      </div>
+      <p>&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item">
+          <a class="p-link--soft" accesskey="8" href="https://www.ubuntu.com/legal">Legal information</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--soft" accesskey="9" href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Cookie policy</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--soft" href="https://github.com/canonical-websites/docs.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a>
+        </li>
+      </ul>
     </div>
-
-    <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+    <div class="col-4">
+      <ul class="p-inline-list u-align--center u-no-margin--top">
+        <li class="p-inline-list__item">
+          <a href="https://twitter.com/ubuntu" title="Share on Twitter"><i class="p-icon--twitter"></i></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="https://www.facebook.com/ubuntulinux/" title="Share on Facebook"><i class="p-icon--facebook"></i></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="https://www.linkedin.com/company-beta/234280/?pathWildcard=234280" title="Share on LinkedIn"><i class="p-icon--linkedin"></i></a>
+        </li>
+      </ul>
+    </div>
   </div>
-</footer>
+</div>
+<div>
+  <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+</div>
 {% endblock footer %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,8 +27,9 @@
 <main id="main-content" class="u-no-margin--top">
   <div class="p-strip--light">
     <div class="row">
-      <h1>Ubuntu documentation</h1>
-      <p class="p-heading--four">The docs directory for all Ubuntu operating systems and products.</p>
+      <div class="col-8">
+      <h1>The docs directory for all Ubuntu operating systems and products.</h1>
+      </div>
     </div>
   </div>
   <div class="p-strip">
@@ -36,95 +37,95 @@
       <h2>Our products</h2>
     </div>
     <div class="row">
-      <ul class="p-matrix">
+      <ul class="p-matrix u-clearfix">
         <li class="p-matrix__item">
-          <a href="https://docs.maas.io/">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="MAAS">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.maas.io/">MAAS&nbsp;</a></h4>
-            <p class="p-matrix__desc">Create a bare-metal cloud with Metal as a Service for IPAM and provisioning</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://docs.maas.io/">MAAS&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Create a bare-metal cloud with Metal as a Service for IPAM and provisioning</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://jujucharms.com/docs/stable/getting-started">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/31c507a5-logo-juju-icon.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/31c507a5-logo-juju-icon.svg" alt="Juju">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://jujucharms.com/docs/stable/getting-started">Juju&nbsp;</a></h4>
-            <p class="p-matrix__desc">Model-driven multi-cloud operations for applications with big data, k8s and openstack solutions</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://jujucharms.com/docs/stable/getting-started">Juju&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Model-driven multi-cloud operations for applications with big data, k8s and openstack solutions</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://docs.snapcraft.io">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/19c7461a-snapcraft-primary-icon--dark.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/19c7461a-snapcraft-primary-icon--dark.svg" alt="Snapcraft">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.snapcraft.io">Snapcraft&nbsp;</a></h4>
-            <p class="p-matrix__desc">A single secure package and auto-update system for Linux distributions</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://docs.snapcraft.io">Snapcraft&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>A single secure package and auto-update system for Linux distributions</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://lxd.readthedocs.io/en/latest/">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://lxd.readthedocs.io/en/latest/">LXD&nbsp;</a></h4>
-            <p class="p-matrix__desc">A pure-container hypervisor. Replace legacy app VMs with containers for speed and density</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://lxd.readthedocs.io/en/latest/">LXD&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>A pure-container hypervisor. Replace legacy app VMs with containers for speed and density</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://docs.ubuntu.com/landscape/en/">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/4964d639-landscape-logo.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/4964d639-landscape-logo.svg" alt="Landscape">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.ubuntu.com/landscape/en/">Landscape&nbsp;</a></h4>
-            <p class="p-matrix__desc">Systems management for Ubuntu - updates, package management, repositories, security</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://docs.ubuntu.com/landscape/en/">Landscape&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Systems management for Ubuntu - updates, package management, repositories, security</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://docs.conjure-up.io/">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c7b173c6-openstack-conjure-up.svg" alt="conjure-up">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.conjure-up.io/">Conjure-up&nbsp;</a></h4>
-            <p class="p-matrix__desc">Use conjure-up to get you a fully installed and usable stack</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://docs.conjure-up.io/">Conjure-up&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Use conjure-up to get you a fully installed and usable stack</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://wiki.ubuntu.com/Mir">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Mir">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://wiki.ubuntu.com/Mir">Mir&nbsp;</a></h4>
-            <p class="p-matrix__desc">Ultra-fast and light Wayland compositor for secure device display management</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://wiki.ubuntu.com/Mir">Mir&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Ultra-fast and light Wayland compositor for secure device display management</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://github.com/CanonicalLtd/multipass">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg" alt="Multipass">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://github.com/CanonicalLtd/multipass">Multipass&nbsp;</a></h4>
-            <p class="p-matrix__desc">Ubuntu virtual machines on demand for Linux, MacOS and Windows</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://github.com/CanonicalLtd/multipass">Multipass&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Ubuntu virtual machines on demand for Linux, MacOS and Windows</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://cloudinit.readthedocs.io/en/latest/">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="cloud-init">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://cloudinit.readthedocs.io/en/latest/">Cloud-init&nbsp;</a></h4>
-            <p class="p-matrix__desc">Apply user data to your instances automatically</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://cloudinit.readthedocs.io/en/latest/">Cloud-init&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Apply user data to your instances automatically</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="/snap-store-proxy/en">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Snapcraft Proxy">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="/snap-store-proxy/en">Snap Store Proxy&nbsp;</a></h4>
-            <p class="p-matrix__desc">The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="/snap-store-proxy/en">Snap Store Proxy&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item u-hide--small">&nbsp;</li>
@@ -133,53 +134,53 @@
     </div>
   </div>
 
-  <div class="p-strip is-bordered u-no-margin--top u-no-padding--top">
+  <div class="p-strip is-shallow u-no-padding--top">
     <div class="row">
       <h2>The Ubuntu OS</h2>
     </div>
     <div class="row">
       <ul class="p-matrix">
         <li class="p-matrix__item">
-          <a href="https://help.ubuntu.com/lts/ubuntu-help">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/cf8634c6-icon-intro-desktop.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/cf8634c6-icon-intro-desktop.svg" alt="Desktop">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://help.ubuntu.com/lts/ubuntu-help">Desktop</a></h4>
-            <p class="p-matrix__desc">The world’s most popular Linux for desktop computing.</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://help.ubuntu.com/lts/ubuntu-help">Desktop</a></h3>
+            <div class="p-matrix__desc">
+              <p>The world’s most popular Linux for desktop computing.</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://help.ubuntu.com/lts/serverguide">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/daeaa851-server.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/d519342f-icon-intro-server.svg" alt="Server">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://help.ubuntu.com/lts/serverguide">Server</a></h4>
-            <p class="p-matrix__desc">Configure a simple file server or build a fifty thousand-node cloud, learn how with the server docs.</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://help.ubuntu.com/lts/serverguide">Server</a></h3>
+            <div class="p-matrix__desc">
+              <p>Configure a simple file server or build a fifty thousand-node cloud, learn how with the server docs.</p>
+            </div>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://docs.ubuntu.com/core/en/">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/91c70f10-iot.svg" alt="Icon">
-          </a>
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Core">
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.ubuntu.com/core/en/">Core</a></h4>
-            <p class="p-matrix__desc">Documentation for the new, transactionally updated Ubuntu for clouds and devices.</p>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://docs.ubuntu.com/core/en/">Core</a></h3>
+            <div class="p-matrix__desc">
+              <p>Documentation for the new, transactionally updated Ubuntu for clouds and devices.</p>
+            </div>
           </div>
         </li>
       </ul>
     </div>
   </div>
 
-  <div class="p-strip--light u-no-margin--btm">
+  <div class="p-strip--light">
     <div class="row">
       <h2>Creating documentation</h2>
+    </div>
       <div class="row">
-        <div class="col-6">
-          <h3><a href="https://docs.ubuntu.com/styleguide/en">Style guide&nbsp;&rsaquo;</a></h3>
-          <p>A guide to the language and style conventions used for Canonical documentation projects.</p>
+        <div class="p-card col-4">
+          <h3 class="p-card__title"><a href="https://docs.ubuntu.com/styleguide/en">Style guide&nbsp;&rsaquo;</a></h3>
+          <p class="p-card__content">A guide to the language and style conventions used for Canonical documentation projects.</p>
         </div>
       </div>
-    </div>
   </div>
 </main>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,9 +3028,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.1.tgz#0d7f5885cdbd1355a9f9d42d7596f9a1258b27ea"
+vanilla-framework@2.0.0-alpha:
+  version "2.0.0-alpha"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.0.0-alpha.tgz#05a0794abc577d66791b2e84bc0207b1e0365b8c"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
- An updated version of the site to v2.0.1
- Updated components, classes, and utilities based on release notes [here](https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/2.0.1)

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8007/](http://0.0.0.0:8007/)
4. View the demo link at https://docs-ubuntu-com-canonical-web-and-design-pr-216.run.demo.haus/

## Screenshot
![Ubuntu documentation](https://user-images.githubusercontent.com/17748020/58318932-af788b00-7e10-11e9-987f-e8a7e77f8bf8.png)

