### PR TITLE
Multistage build and standardize build id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,28 @@
+# syntax=docker/dockerfile:experimental
+
+# Build stage: Install python dependencies
+# ===
+FROM ubuntu:bionic AS python-dependencies
+RUN apt update && apt install --no-install-recommends --yes python3 python3-pip python3-setuptools
+ADD requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
+
+# # Build the production image
+# # ===
 FROM ubuntu:bionic
 
-# Set up environment
-ENV LANG C.UTF-8
-WORKDIR /srv
+# Install python and import python dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-lib2to3 python3-pkg-resources
+COPY --from=python-dependencies /root/.local/lib/python3.6/site-packages /root/.local/lib/python3.6/site-packages
+COPY --from=python-dependencies /root/.local/bin /root/.local/bin
+ENV PATH="/root/.local/bin:${PATH}"
 
-# System dependencies
-RUN apt-get update && apt-get install --yes python3-pip net-tools
-
-# Import code, install code dependencies
 ADD . .
-RUN pip3 install -r requirements.txt
 
-# Set git commit ID
-ARG COMMIT_ID
-RUN test -n "${COMMIT_ID}"
-RUN echo "${COMMIT_ID}" > version-info.txt
+# Set build id (standardized)
+ARG BUILD_ID
+ENV TALISKER_REVISION_ID "${BUILD_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
-


### PR DESCRIPTION
## Done

- Implemented multistage build to reduce docker image sizes using reference from ubuntu.com
- Fixed: previous docker image building did not work

## QA

- Changes should not affect site
- Check image size: `docker build --tag myimage && docker images` check myimage size
- Revision ID is correctly added in the headers: `docker build --tag myimage --build-arg BUILD_ID=myfakeid .`
- `docker run -ti -p 8111:80 myimage`
- `curl -I http://localhost:8111` to see if headers display "myfakeid"


## Issue / Card

- Multistage builds issue (WUB Fix #2142)
- Standardize build-ids (WUB Fix #2096)