### PR TITLE
Change version gitdb since v3.0.2 breaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:10-slim AS yarn-dependencies
+FROM node:12-slim AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 FROM ubuntu:bionic AS build-documentation
 WORKDIR /srv
 RUN apt-get update && apt-get install --no-install-recommends --yes git ca-certificates python3 python3-pip python3-setuptools
-RUN pip3 install ubuntudesign.documentation-builder
+RUN pip3 install ubuntudesign.documentation-builder gitdb2==3.0.1
 ADD build-docs.sh build-docs.sh
 ADD .git/index /dev/null
 RUN ./build-docs.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ gevent==1.4.0
 talisker[gunicorn]==0.15.0
 whitenoise==5.0.1
 ubuntudesign.documentation-builder==1.6.2
+gitdb2==3.0.1


### PR DESCRIPTION
## Done

It seems that gitdb breaks since v3.0.2 with this error:

```
Traceback (most recent call last):
  File "/home/toto/.pyenv/versions/docs.ubuntu.com/bin/documentation-builder", line 8, in <module>
    from ubuntudesign.documentation_builder import cli
  File "/home/toto/.pyenv/versions/3.6.5/envs/docs.ubuntu.com/lib/python3.6/site-packages/ubuntudesign/documentation_builder/cli.py", line 7, in <module>
    from .builder import Builder
  File "/home/toto/.pyenv/versions/3.6.5/envs/docs.ubuntu.com/lib/python3.6/site-packages/ubuntudesign/documentation_builder/builder.py", line 19, in <module>
    from .operations import (
  File "/home/toto/.pyenv/versions/3.6.5/envs/docs.ubuntu.com/lib/python3.6/site-packages/ubuntudesign/documentation_builder/operations.py", line 13, in <module>
    from git import Repo
  File "/home/toto/.pyenv/versions/3.6.5/envs/docs.ubuntu.com/lib/python3.6/site-packages/git/__init__.py", line 38, in <module>
    from git.exc import *                       # @NoMove @IgnorePep8
  File "/home/toto/.pyenv/versions/3.6.5/envs/docs.ubuntu.com/lib/python3.6/site-packages/git/exc.py", line 9, in <module>
    from git.compat import UnicodeMixin, safe_decode, string_types
  File "/home/toto/.pyenv/versions/3.6.5/envs/docs.ubuntu.com/lib/python3.6/site-packages/git/compat.py", line 16, in <module>
    from gitdb.utils.compat import (
ModuleNotFoundError: No module named 'gitdb.utils.compat'
```

To help deploying the app I pinned the version in the dockerfile to v3.0.1 which doens't break.

## QA

- ` DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag docs.ubuntu.com .`
- `docker run -ti -p 8001:80 docs.ubuntu.com`

## Issue / Card

Fixes #233