### PR TITLE
Add redirect for server-certs fips doc

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -17,6 +17,9 @@ snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 landscape/en/landscape-api/?: /landscape/en/api
 landscape/en/onprem-overview/?: /landscape/en/onprem
 
+# security-certs
+security-certs/en/fips-16/?: /security-certs/en/fips
+
 # Documentation-builder
 documentation-builder/?: https://github.com/canonical-webteam/documentation-builder/tree/master/docs
 documentation-builder/(?P<page>.*)/: https://github.com/canonical-webteam/documentation-builder/tree/master/docs/{page}


### PR DESCRIPTION
## Done

- Added a redirect so that /security-certs/en/fips-16 goes to /security-certs/en/fips

## QA

1. Download this branch
2. Go to https://0.0.0.0:8007/security-certs/en/fips-16
3. See that you are redirected to https://0.0.0.0:8007/security-certs/en/fips
