### PR TITLE
Update desktop docs link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -151,7 +151,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/cf8634c6-icon-intro-desktop.svg" alt="Desktop">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://help.ubuntu.com/lts/ubuntu-help">Desktop</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://help.ubuntu.com/stable/ubuntu-help">Desktop</a></h3>
             <div class="p-matrix__desc">
               <p>The world’s most popular Linux for desktop computing.</p>
             </div>


### PR DESCRIPTION
## Done

- Use help.ubuntu.com/stable/ubuntu-help for the desktop guide instead of help.ubuntu.com/lts/ubuntu-help

## QA

See that the desktop docs now goes to the /stable/ version

## Issue / Card

Fixes #154
