### PR TITLE
Update spelling of OpenStack, remove conjure-ip docs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -50,7 +50,7 @@
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link" href="https://jaas.ai/docs">Juju&nbsp;</a></h3>
             <div class="p-matrix__desc">
-              <p>Model-driven multi-cloud operations for applications with big data, k8s and openstack solutions</p>
+              <p>Model-driven multi-cloud operations for applications with big data, k8s and OpenStack solutions</p>
             </div>
           </div>
         </li>
@@ -82,11 +82,11 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c7b173c6-openstack-conjure-up.svg" alt="conjure-up">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Snapcraft Proxy">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://docs.conjure-up.io/">Conjure-up&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="/snap-store-proxy/en">Snap Store Proxy&nbsp;</a></h3>
             <div class="p-matrix__desc">
-              <p>Use conjure-up to get you a fully installed and usable stack</p>
+              <p>The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
             </div>
           </div>
         </li>
@@ -118,15 +118,6 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Snapcraft Proxy">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="/snap-store-proxy/en">Snap Store Proxy&nbsp;</a></h3>
-            <div class="p-matrix__desc">
-              <p>The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
-            </div>
-          </div>
-        </li>
-        <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="dqlite">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link" href="https://dqlite.io/docs/">Dqlite&nbsp;</a></h3>
@@ -134,6 +125,9 @@
               <p>Dqlite is a fast, embedded, persistent SQL database with Raft consensus that is perfect for fault-tolerant IoT and Edge devices.</p>
             </div>
           </div>
+        </li>
+        <li class="p-matrix__item">
+          &nbsp;
         </li>
         <li class="p-matrix__item">&nbsp;</li>
       </ul>


### PR DESCRIPTION
## Done

- Update spelling of OpenStack
- Remove conjure-ip docs
- Updated the [copy doc](https://docs.google.com/document/d/1mcfPYByoIT_iFOot6fxqq_bXX9p9vENWkLt4-ZI22Qg/edit)

## QA

1. Dowload this branch and ./run
2. Look at http://0.0.0.0:8007/
3. See that OpenStack has the right titles and that conjure-up docs are removed

## Issue / Card

Fixes #248
