### PR TITLE
Don't try to deploy subsections

### DIFF
--- a/deploy/site.yaml
+++ b/deploy/site.yaml
@@ -10,52 +10,12 @@ readinessPath: "/"
 production:
   replicas: 5
 
-  routes:
-    - paths: [/core]
-      name: docs-ubuntu-com-core
-      app_name: docs.ubuntu.com-core
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core
-      replicas: 5
-      readinessPath: "/"
-    - paths: [/phone]
-      name: docs-ubuntu-com-phone
-      app_name: docs.ubuntu.com-phone
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone
-      replicas: 5
-      readinessPath: "/"
-    - paths: [/security-certs]
-      name: docs-ubuntu-com-security-certs
-      app_name: docs.ubuntu.com-security-certs
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-security-certs
-      replicas: 5
-      readinessPath: "/"
-
   nginxConfigurationSnippet: |
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
 
 # Overrides for staging
 staging:
   replicas: 3
-
-  routes:
-    - paths: [/core]
-      name: docs-ubuntu-com-core
-      app_name: docs.ubuntu.com-core
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core
-      replicas: 3
-      readinessPath: "/"
-    - paths: [/phone]
-      name: docs-ubuntu-com-phone
-      app_name: docs.ubuntu.com-phone
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone
-      replicas: 3
-      readinessPath: "/"
-    - paths: [/security-certs]
-      name: docs-ubuntu-com-security-certs
-      app_name: docs.ubuntu.com-security-certs
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-security-certs
-      replicas: 3
-      readinessPath: "/"
 
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";


### PR DESCRIPTION
docs.ubuntu.com doesn't have the information to deploy to /phone, /security-certs, /core. These are separate routes precisely because they are built from other codebases - https://github.com/CanonicalLtd/security-certs-docs/, https://github.com/canonical-web-and-design/ubuntu-core-docs/.

At the moment, docs.ubuntu.com is trying to append the single image tag to different images to roll out to those three routes, which will always fail because those images haven't been built.

So we need to remove these routes from this file.