### PR TITLE
Redirections for core, phone and security-certs

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -2,33 +2,11 @@ domain: docs.ubuntu.com
 
 image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com
 
-useProxy: false
-
 readinessPath: "/"
 
 # Overrides for production
 production:
   replicas: 5
-
-  routes:
-    - paths: [/core]
-      name: docs-ubuntu-com-core
-      app_name: docs.ubuntu.com-core
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core
-      replicas: 5
-      readinessPath: "/"
-    - paths: [/phone]
-      name: docs-ubuntu-com-phone
-      app_name: docs.ubuntu.com-phone
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone
-      replicas: 5
-      readinessPath: "/"
-    - paths: [/security-certs]
-      name: docs-ubuntu-com-security-certs
-      app_name: docs.ubuntu.com-security-certs
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-security-certs
-      replicas: 5
-      readinessPath: "/"
 
   nginxConfigurationSnippet: |
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
@@ -36,26 +14,6 @@ production:
 # Overrides for staging
 staging:
   replicas: 3
-
-  routes:
-    - paths: [/core]
-      name: docs-ubuntu-com-core
-      app_name: docs.ubuntu.com-core
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-core
-      replicas: 3
-      readinessPath: "/"
-    - paths: [/phone]
-      name: docs-ubuntu-com-phone
-      app_name: docs.ubuntu.com-phone
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-phone
-      replicas: 3
-      readinessPath: "/"
-    - paths: [/security-certs]
-      name: docs-ubuntu-com-security-certs
-      app_name: docs.ubuntu.com-security-certs
-      image: prod-comms.docker-registry.canonical.com/docs.ubuntu.com-security-certs
-      replicas: 3
-      readinessPath: "/"
 
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -36,3 +36,6 @@ documentation-builder/(?P<page>.*[^/])?(.html)?: https://github.com/canonical-we
 
 # Redirect to www.ubuntu.com search
 search/?$: https://www.ubuntu.com/search
+
+# core, phone and security-certs subdomains
+(?P<project>(core|phone|security-certs))(/en)?/?(?P<path>.*): https://{project}.docs.ubuntu.com/en/{path}


### PR DESCRIPTION
## Done

Redirections for core, phone and security-certs

## QA

Build the docker image:
`DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag test .`

Run the website locally:
`docker run -ti -p "8007:80" --env SECRET_KEY=secret_key test`

Go to any of the following addresses and check that the redirection is working
https://docs.ubuntu.com/core/en/guides/build-device/board-enablement
https://docs.ubuntu.com/phone/en/platform/sdk/
https://docs.ubuntu.com/security-certs/en/fips-cloud-containers

Try with any address under /core, /phone or /security-certs you should get redirected to their new subdomains.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2970
