### PR TITLE
Add missing products to index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -153,9 +153,7 @@
             </div>
           </div>
         </li>
-        <li class="p-matrix__item">
-          &nbsp;
-        </li>
+        <li class="p-matrix__item">&nbsp;</li>
         <li class="p-matrix__item">&nbsp;</li>
       </ul>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -127,6 +127,33 @@
           </div>
         </li>
         <li class="p-matrix__item">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/8dd22a22-menu-icon--product-kubernetes.svg" alt="MicroK8s">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title"><a class="p-link" href="https://microk8s.io/docs">MicroK8s&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>The smallest, simplest, pure production K8s. For clusters, laptops, IoT and Edge, on Intel and ARM</p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/8dd22a22-menu-icon--product-kubernetes.svg" alt="Charmed Kubernetes">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title"><a class="p-link" href="https://ubuntu.com/kubernetes/docs">Charmed Kubernetes&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring</p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0fbee9c4-pictogram_internet01.svg" alt="Netplan">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title"><a class="p-link" href="https://netplan.io/reference">Netplan&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Network abstraction for Linux to simplify and standardise complex network configuration</p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
           &nbsp;
         </li>
         <li class="p-matrix__item">&nbsp;</li>


### PR DESCRIPTION
## Done

- Add links to the MicroK8s, Charmed Kubernetes and Netplan documentation to index.html

## QA

- Check out this feature branch
- Run `./run` and visit http://0.0.0.0:8007/ to view locally in your browser
- Ensure that the aforementioned links are present, with appropriate descriptions and icons
- Ensure that the new code is consistent in style to the rest of the code
- If you know of any more documentation for Canonical products that have not been linked, let me know and I'll add it

## Issue / Card

Fixes #242 