### PR TITLE
Move to a new GTM container

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -61,7 +61,7 @@ build_docs () {
                             --search-placeholder "Search Style Guide docs"  \
                             --search-domain "docs.ubuntu.com/${name}"  \
                             --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-K92JCQ"  \
+                            --tag-manager-code "GTM-KNX3CJC"  \
                             --no-link-extensions
     fi
 
@@ -81,7 +81,7 @@ build_docs () {
                             --search-placeholder "Search Landscape docs"  \
                             --search-domain "docs.ubuntu.com/${name}"  \
                             --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-K92JCQ"  \
+                            --tag-manager-code "GTM-KNX3CJC"  \
                             --no-link-extensions
     fi
 
@@ -101,7 +101,7 @@ build_docs () {
                             --search-placeholder "Search Snap Store Proxy docs"  \
                             --search-domain "docs.ubuntu.com/${name}"  \
                             --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-K92JCQ"  \
+                            --tag-manager-code "GTM-KNX3CJC"  \
                             --no-link-extensions
     fi
 }

--- a/templates/includes/layout.html
+++ b/templates/includes/layout.html
@@ -11,7 +11,7 @@
       }); var f = d.getElementsByTagName(s)[0],
         j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
           'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', 'GTM-K92JCQ');</script>
+    })(window, document, 'script', 'dataLayer', 'GTM-KNX3CJC');</script>
   <!-- End Google Tag Manager -->
 
   <meta charset="UTF-8" />
@@ -27,7 +27,7 @@
 <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KNX3CJC" height="0" width="0" style="display:none;visibility:hidden"></iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->
 


### PR DESCRIPTION
## Done

- to make moving to the new cookie policy, I am moving as many sites out of the ubuntu.com container as possible

## QA

- download and `.run` (not dotrun) the site
- view the source and see the docs are now using the `GTM-KNX3CJC` container

## Issue / Card

Fixes #264 
