### PR TITLE
Update LXD docs URL to current location

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -66,7 +66,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://lxd.readthedocs.io/en/latest/">LXD&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://linuxcontainers.org/lxd/docs/master/">LXD&nbsp;</a></h3>
             <div class="p-matrix__desc">
               <p>A pure-container hypervisor. Replace legacy app VMs with containers for speed and density</p>
             </div>


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>

## Done

Update LXD docs URL to current location (https://linuxcontainers.org/lxd/docs/master/)
