### PR TITLE
Fix homepage URL and remove search

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -57,9 +57,6 @@ build_docs () {
                             --site-root "/${name}/"  \
                             --output-path "templates/${name}"  \
                             --output-media-path "static/media/${name}"  \
-                            --search-url "/search"  \
-                            --search-placeholder "Search Style Guide docs"  \
-                            --search-domain "docs.ubuntu.com/${name}"  \
                             --media-url "/static/media/${name}"  \
                             --tag-manager-code "GTM-KNX3CJC"  \
                             --no-link-extensions

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -26,7 +26,7 @@ documentation-builder/(?P<page>.*[^/])?(.html)?: https://github.com/canonical-we
 # ===
 
 # Redirect project section roots to English language
-(?P<project>(landscape|snap-store-proxy))/?: /{project}/en/
+(?P<project>(landscape|snap-store-proxy|styleguide))/?: /{project}/en/
 
 # Add slash to language and version folders, and remove "index"
 (?P<project>(landscape|snap-store-proxy))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
@@ -37,8 +37,5 @@ documentation-builder/(?P<page>.*[^/])?(.html)?: https://github.com/canonical-we
 # Redirect to www.ubuntu.com search
 search/?$: https://www.ubuntu.com/search
 
-# core, phone and security-certs subdomains
-(?P<project>(core|phone|security-certs))(/en)?/?(?P<path>.*): https://{project}.docs.ubuntu.com/en/{path}
-
-# Fix styleguide homepage URL
-styleguide/?: /styleguide/en
+# core, phone subdomains
+(?P<project>(core|phone))(/en)?/?(?P<path>.*): https://{project}.docs.ubuntu.com/en/{path}

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -39,3 +39,6 @@ search/?$: https://www.ubuntu.com/search
 
 # core, phone and security-certs subdomains
 (?P<project>(core|phone|security-certs))(/en)?/?(?P<path>.*): https://{project}.docs.ubuntu.com/en/{path}
+
+# Fix styleguide homepage URL
+styleguide/?: /styleguide/en

--- a/templates/index.html
+++ b/templates/index.html
@@ -218,7 +218,7 @@
     </div>
     <div class="row">
       <div class="p-card col-4">
-        <h4 class="p-card__title"><a href="https://docs.ubuntu.com/styleguide/en">Style guide&nbsp;&rsaquo;</a></h4>
+        <h4 class="p-card__title"><a href="/styleguide/en">Style guide&nbsp;&rsaquo;</a></h4>
         <p class="p-card__content">A guide to the language and style conventions used for Canonical documentation projects.</p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Fixed styleguide homepage link
- Removed 'not very useful' search

See issues section for further info

## QA

- Check that https://docs-ubuntu-com-310.demos.haus/styleguide redirects to https://docs-ubuntu-com-310.demos.haus/styleguide/en. This fixes the homepage link on /styleguide
- Check on this very page that the search is removed.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/docs.ubuntu.com/issues/213
Fixes https://github.com/canonical-web-and-design/docs.ubuntu.com/issues/158
