### PR TITLE
Pin MarkupSafe to avoid the script breaking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 FROM ubuntu:focal AS build-documentation
 WORKDIR /srv
 RUN apt-get update && apt-get install --no-install-recommends --yes git ca-certificates python3 python3-pip python3-setuptools
-RUN pip3 install ubuntudesign.documentation-builder gitdb2==3.0.1
+RUN pip3 install ubuntudesign.documentation-builder gitdb2==3.0.1 MarkupSafe==2.0.1
 ADD build-docs.sh build-docs.sh
 ADD .git/index /dev/null
 RUN ./build-docs.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ talisker[gunicorn,gevent]==0.19.0
 whitenoise==5.3.0
 ubuntudesign.documentation-builder==1.6.5
 gitdb2==3.0.3.post1
+MarkupSafe==2.0.1


### PR DESCRIPTION
## Done
 
Pin `MarkupSafe` to avoid the `build-docs.sh` script breaking.

## QA

- Checkout branch and try to build the docs, make sure it succeeds.
