### PR TITLE
Docker: Copy templates and media from the build-documentation stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,8 @@ ADD . .
 RUN rm -rf package.json yarn.lock .babelrc webpack.config.js .git
 COPY --from=build-css /srv/static/css static/css
 COPY --from=build-js /srv/static/js static/js
-COPY --from=build-documentation /srv/templates/* templates/.
-COPY --from=build-documentation /srv/static/media/* static/media/.
+COPY --from=build-documentation /srv/templates templates
+COPY --from=build-documentation /srv/static/media static/media
 
 # Set build id (standardized)
 ARG BUILD_ID


### PR DESCRIPTION
## Done
Current image is in an incomplete state because the templates being generated by documentation-builder were not being copied properly. You can check https://docs.staging.ubuntu.com/snap-store-proxy/en/ 404's.

## QA

- Checkout this branch
- `DOCKER_BUILDKIT=1 docker build -t docs .`
- `docker run -ti -p 8007:80 docs`
-  Go to localhost:8007/snap-store-proxy/en/ and make sure you see the page
